### PR TITLE
project_task_kanban_examples: description missing a color bullet

### DIFF
--- a/addons/project/static/src/js/project_task_kanban_examples.js
+++ b/addons/project/static/src/js/project_task_kanban_examples.js
@@ -4,8 +4,8 @@ import { _lt } from 'web.core';
 import {Markup} from 'web.utils';
 import kanbanExamplesRegistry from 'web.kanban_examples_registry';
 
-const greenBullet = Markup`<span class="o_status o_status_green"></span>`;
-const redBullet = Markup`<span class="o_status o_status_red"></span>`;
+const greenBullet = Markup`<span class="o_status d-inline-block o_status_green"></span>`;
+const redBullet = Markup`<span class="o_status d-inline-block o_status_red"></span>`;
 const star = Markup`<a style="color: gold;" class="fa fa-star"/>`;
 const clock = Markup`<a class="fa fa-clock-o" />`;
 


### PR DESCRIPTION
### Description missing bullet with color in kanban examples

**Impacted versions:**
 
 - 15.0
 
**Steps to reproduce:**
 
 1. create a new project
 2. click "See examples" on kanban view
 3. kanban examples dialog will popup, description will show at the right panel
 
**Description of the issue/feature this PR addresses:**

Add a class as same as kanban view's stage dot doing to let display:inline-block work and show the bullet with color.

**Current behavior before PR:**
 
Description show at below:
Use the button to signalize to your colleagues that a task is ready for the next stage.
Use the to signalize a problem or a need for discussion on a task.

**Desired behavior after PR is merged:**

Description show at below:
Use the • button to signalize to your colleagues that a task is ready for the next stage.
Use the • to signalize a problem or a need for discussion on a task.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr